### PR TITLE
fix: revert header to simpler version without titles

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -6,16 +6,12 @@
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
     <meta http-equiv="Pragma" content="no-cache">
     <meta http-equiv="Expires" content="0">
-    <title>Course Materials Assistant</title>
+    <title>RAG Chatbot</title>
     <link rel="stylesheet" href="style.css?v=11">
 </head>
 <body>
     <div class="container">
         <header>
-            <div class="header-content">
-                <h1>Course Materials Assistant</h1>
-                <p class="subtitle">Ask questions about courses, instructors, and content</p>
-            </div>
             <button id="themeToggle" class="theme-toggle" aria-label="Toggle theme">
                 <svg class="theme-icon sun-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                     <circle cx="12" cy="12" r="5"></circle>

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -81,32 +81,16 @@ body {
     padding: 0;
 }
 
-/* Header - Visible with toggle button */
+/* Header - Minimal with only toggle button */
 header {
     display: flex;
-    justify-content: space-between;
+    justify-content: flex-end;
     align-items: center;
-    padding: 1.5rem 2rem;
+    padding: 1rem 2rem;
     background: var(--surface);
-    border-bottom: 1px solid var(--border-color);
     flex-shrink: 0;
 }
 
-header h1 {
-    font-size: 1.75rem;
-    font-weight: 700;
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-    background-clip: text;
-    margin: 0;
-}
-
-.subtitle {
-    font-size: 0.95rem;
-    color: var(--text-secondary);
-    margin-top: 0.5rem;
-}
 
 /* Theme Toggle Button */
 .theme-toggle {
@@ -168,11 +152,6 @@ header h1 {
     transform: rotate(0deg) scale(1);
 }
 
-/* Header content wrapper */
-.header-content {
-    display: flex;
-    flex-direction: column;
-}
 
 /* Main Content Area with Sidebar */
 .main-content {
@@ -827,11 +806,8 @@ details[open] .new-chat-header::before {
     
     header {
         display: flex;
+        justify-content: flex-end;
         padding: 1rem;
-    }
-    
-    header h1 {
-        font-size: 1.5rem;
     }
     
     .theme-toggle {


### PR DESCRIPTION
Fixes #2

Reverted the header to a simpler design as requested:

- Removed "Course Materials Assistant" h1 heading
- Removed "Ask questions about courses..." subtitle
- Removed header border-bottom styling
- Preserved theme toggle button (right-aligned)
- Updated page title to "RAG Chatbot"
- Cleaned up unused CSS styles
- Fixed mobile responsive layout

The header now has a minimal, clean appearance with just the theme toggle.

Generated with [Claude Code](https://claude.ai/code)